### PR TITLE
Make unnecessary runtime dependencies into dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,20 @@
 {
   "name": "css-arith",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "css-arith",
-      "version": "1.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "@types/node": "^20.8.10",
-        "typescript": "^5.2.2"
-      },
+      "version": "1.1.2",
+      "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.7",
+        "@types/node": "^20.8.10",
         "jest": "^29.7.0",
         "jsdom": "^22.1.0",
-        "ts-jest": "^29.1.1"
+        "ts-jest": "^29.1.1",
+        "typescript": "^5.2.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1126,6 +1124,7 @@
       "version": "20.8.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
       "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3918,6 +3917,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3929,7 +3929,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
   "repository": "https://github.com/hopansh/css-arith.git",
   "author": "",
   "license": "MIT",
-  "dependencies": {
-    "@types/node": "^20.8.10",
-    "typescript": "^5.2.2"
-  },
   "devDependencies": {
+    "@types/node": "^20.8.10",
+    "typescript": "^5.2.2",
     "@types/jest": "^29.5.7",
     "jest": "^29.7.0",
     "jsdom": "^22.1.0",


### PR DESCRIPTION
I really like how simple this library is to use, however I noticed that you had marked `typescript` and `@types/node` as runtime dependencies, however they appear unnecessary. I moved them to `devDependencies` and reran the tests and everything passes. This should slim down the install size a lot!